### PR TITLE
docs: docstrings across core/ (C++, Python, Starlark)

### DIFF
--- a/core/communication/dds_context.hpp
+++ b/core/communication/dds_context.hpp
@@ -15,8 +15,16 @@ namespace core::communication {
 
 namespace dds = eprosima::fastdds::dds;
 
+/// @brief Owns a FastDDS DomainParticipant and the topics registered to it.
+///
+/// Topics are created on first request and reused on subsequent calls with the
+/// same name. Participant and topic lifetime is managed through RAII deleters.
+/// Non-copyable; move-constructible.
 class DDSContext {
  public:
+  /// @brief Constructs the context and creates a DomainParticipant with the given name.
+  /// @param domain_participant_name Name assigned to the FastDDS DomainParticipant.
+  /// @throws std::runtime_error if participant creation fails.
   DDSContext(const std::string& domain_participant_name) {
     dds::DomainParticipantQos participantQos;
     participantQos.name(domain_participant_name);
@@ -39,6 +47,9 @@ class DDSContext {
 
   ~DDSContext() = default;
 
+  /// @brief Get or create a topic from a @c TopicSpec.
+  /// @tparam Spec A @c TopicSpec specialization. Derives topic name and PubSubType from it.
+  /// @return Pointer to the FastDDS topic. Owned by this context.
   template <typename Spec>
   dds::Topic* GetDDSTopic() {
     static_assert(is_topic_spec_v<Spec>,
@@ -47,6 +58,15 @@ class DDSContext {
     return GetDDSTopic<typename Spec::type>(Spec::kName);
   }
 
+  /// @brief Get or create a topic by PubSubType and name.
+  ///
+  /// Registers the type on first call, then creates the DDS topic.
+  /// Returns the existing topic if one with @p topic_name already exists.
+  ///
+  /// @tparam PubSubType FastDDS PubSubType. Must derive from @c TopicDataType.
+  /// @param  topic_name DDS topic name string.
+  /// @return Pointer to the FastDDS topic. Owned by this context.
+  /// @throws std::runtime_error if topic creation fails.
   template <typename PubSubType>
   dds::Topic* GetDDSTopic(const std::string& topic_name) {
     static_assert(std::is_base_of_v<dds::TopicDataType, PubSubType>,
@@ -74,6 +94,9 @@ class DDSContext {
     return raw_topic;
   }
 
+  /// @brief Returns the shared domain participant.
+  ///        Callers may hold the returned @c shared_ptr to extend participant
+  ///        lifetime beyond this context.
   std::shared_ptr<dds::DomainParticipant> GetDomainParticipant() {
     return participant_;
   }
@@ -91,13 +114,21 @@ class DDSContext {
   std::vector<TopicPtr> topics_;
 };
 
+/// @brief Singleton accessor for the process-wide @c DDSContext.
+///
+/// The instance is constructed on first call to @c Get(), using the name set
+/// via @c SetName(). Call @c SetName() once at startup before any pub/sub is
+/// created. Non-instantiable — all access is through static methods.
 class DDSContextProvider {
  public:
   DDSContextProvider(const DDSContextProvider&) = delete;
   DDSContextProvider& operator=(const DDSContextProvider&) = delete;
 
+  /// @brief Sets the DomainParticipant name used when the singleton is first constructed.
+  ///        Must be called before the first @c Get() invocation. No effect after construction.
   static void SetName(std::string name) { name_ = std::move(name); }
 
+  /// @brief Returns the singleton @c DDSContext, constructing it on first call.
   static DDSContext& Get() {
     using Deleter = std::function<void(DDSContext*)>;
 

--- a/core/communication/dds_publisher.hpp
+++ b/core/communication/dds_publisher.hpp
@@ -45,6 +45,14 @@ class PubListener : public dds::DataWriterListener {
 };
 }  // namespace
 
+/// @brief Wraps a FastDDS DataWriter for a single topic.
+///
+/// Call @c Start() once to create the publisher and data writer, then
+/// @c Publish() to send messages. Writes only when at least one subscriber
+/// is matched; silent no-op otherwise.
+///
+/// @tparam PubSubType FastDDS PubSubType. Must derive from @c TopicDataType.
+///                    The inner @c ::type alias gives the message payload type.
 template <typename PubSubType>
 class DDSPublisher {
   static_assert(
@@ -56,6 +64,10 @@ class DDSPublisher {
 
   DDSPublisher() = default;
 
+  /// @brief Creates the FastDDS Publisher and DataWriter for the given topic.
+  ///        Retrieves the DomainParticipant from @c DDSContextProvider.
+  /// @param topic_name DDS topic name.
+  /// @throws std::runtime_error if Publisher or DataWriter creation fails.
   void Start(const std::string& topic_name) {
     // we store a pointer to participant for lifecycle mgmt of publisher and
     // data writer
@@ -86,6 +98,8 @@ class DDSPublisher {
             });
   }
 
+  /// @brief Writes @p payload to the topic if at least one subscriber is matched.
+  /// @return True if the write succeeded; false if unmatched or write failed.
   bool Publish(const DDSDataType& payload) {
     if (listener_.matched_count_ > 0) {
       return writer_->write(const_cast<DDSDataType*>(&payload)) ==
@@ -94,6 +108,7 @@ class DDSPublisher {
     return false;
   }
 
+  /// @return True if at least one subscriber is currently matched.
   [[nodiscard]] bool IsMatched() const { return listener_.matched_count_ > 0; }
 
  private:

--- a/core/communication/dds_subscriber.hpp
+++ b/core/communication/dds_subscriber.hpp
@@ -76,6 +76,14 @@ class SubListener : public dds::DataReaderListener {
 };
 }  // namespace
 
+/// @brief Wraps a FastDDS DataReader for a single topic, with a fixed-size sample queue.
+///
+/// Incoming samples are pushed into a @c SizeConstrainedQueue by the listener callback.
+/// Call @c DrainQueue() to transfer all buffered samples at once (used by
+/// @c DataEndpoint::Sync()), or @c GetSample() to consume one sample at a time.
+///
+/// @tparam PubSubType FastDDS PubSubType. Must derive from @c TopicDataType.
+/// @tparam QueueSize  Maximum number of samples buffered (default: 1).
 template <typename PubSubType, std::size_t QueueSize = 1>
 class DDSSubscriber {
   static_assert(
@@ -88,6 +96,10 @@ class DDSSubscriber {
 
   DDSSubscriber() = default;
 
+  /// @brief Creates the FastDDS Subscriber and DataReader for the given topic.
+  ///        Retrieves the DomainParticipant from @c DDSContextProvider.
+  /// @param topic_name DDS topic name.
+  /// @throws std::runtime_error if Subscriber or DataReader creation fails.
   void Start(const std::string& topic_name) {
     // we store a pointer to participant for lifecycle mgmt of subscriber and
     // data reader
@@ -118,12 +130,17 @@ class DDSSubscriber {
   }
   ~DDSSubscriber() = default;
 
+  /// @return True if at least one publisher is currently matched.
   [[nodiscard]] bool IsMatched() const { return listener_.matched_count_ > 0; }
 
+  /// @brief Dequeues and returns the most recent sample.
+  /// @return The sample, or @c std::nullopt if the queue is empty.
   std::optional<DDSDataType> GetSample() {
     return std::move(listener_.GetSample());
   }
 
+  /// @brief Transfers all buffered samples from the listener queue into @p other.
+  ///        Replaces the contents of @p other entirely. Used by @c DataEndpoint::Sync().
   inline void DrainQueue(
       utils::SizeConstrainedQueue<DDSDataType, QueueSize>& other) noexcept {
     listener_.DrainQueue(other);

--- a/core/communication/topic_spec.hpp
+++ b/core/communication/topic_spec.hpp
@@ -9,6 +9,16 @@ namespace core::communication {
 
 namespace dds = eprosima::fastdds::dds;
 
+/// @brief Compile-time descriptor binding a FastDDS PubSubType to a named topic and queue depth.
+///
+/// Pass specializations of this struct as template arguments to @c DataEndpoint,
+/// @c DDSPublisher, and @c DDSSubscriber. All three parameters are resolved at
+/// compile time — no runtime overhead for topic lookup.
+///
+/// @tparam T              FastDDS PubSubType. Must derive from @c TopicDataType.
+///                        The inner @c ::type alias gives the message payload type.
+/// @tparam TopicName      Null-terminated string literal identifying the DDS topic.
+/// @tparam max_queue_size Maximum samples buffered in the subscriber queue (default: 1).
 template <typename T, const char* TopicName, size_t max_queue_size = 1>
 struct TopicSpec {
   static_assert(std::is_base_of_v<dds::TopicDataType, T>,
@@ -19,12 +29,15 @@ struct TopicSpec {
   static constexpr size_t kQueueSize{max_queue_size};
 };
 
+/// @brief Detects whether @p T is a @c TopicSpec specialization.
+/// @tparam T Type to test. Evaluates to @c std::true_type for any @c TopicSpec<...>.
 template <typename T>
 struct is_topic_spec : std::false_type {};
 
 template <typename T, const char* TopicName, size_t Q>
 struct is_topic_spec<TopicSpec<T, TopicName, Q>> : std::true_type {};
 
+/// @brief True iff @p T is a @c TopicSpec specialization.
 template <typename T>
 inline constexpr bool is_topic_spec_v = is_topic_spec<T>::value;
 

--- a/core/generators/cc_utils.bzl
+++ b/core/generators/cc_utils.bzl
@@ -1,4 +1,4 @@
-"""This makes the linter happy"""
+"""Shared Bazel utility for compiling generated C++ files into a cc_library target."""
 
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")

--- a/core/generators/dds_ports_gen.bzl
+++ b/core/generators/dds_ports_gen.bzl
@@ -1,3 +1,9 @@
+"""Bazel rule for generating DDS port headers from YAML and IDL inputs.
+
+Produces five headers per target: pub_ids, pub_specs, sub_ids, sub_specs, dds_types.
+Prefer the cc_dds_components macro in defs.bzl for standard usage.
+"""
+
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//core/generators:cc_utils.bzl", "pack_cc_library")
 

--- a/core/generators/defs.bzl
+++ b/core/generators/defs.bzl
@@ -1,4 +1,8 @@
-"""This Makes the linter happy"""
+"""Public macros for generating DDS components and task parameters.
+
+Preferred entry points over the underlying rules — they wire dependencies
+and naming conventions automatically.
+"""
 
 load("//core/generators:dds_ports_gen.bzl", _cc_dds_ports = "cc_dds_ports")
 load("//core/generators:fastdds_types_gen.bzl", _cc_fastdds_types = "cc_fastdds_types")
@@ -31,6 +35,15 @@ def cc_dds_components(name, idls, ports_yaml, namespace = "gen"):
     )
 
 def cc_parameters(name, yaml_parameters, namespace = "gen"):
+    """Generates a C++ parameters header from a YAML parameter set definition.
+
+    Wraps the cc_parameters rule; pulls in parameters_provider as a default dep.
+
+    Args:
+        name: A unique name for this target.
+        yaml_parameters: YAML file defining the parameter set.
+        namespace: C++ namespace for generated code (default: "gen").
+    """
     _cc_parameters(
         name = name,
         yaml_config = yaml_parameters,

--- a/core/generators/gen_data_models.py
+++ b/core/generators/gen_data_models.py
@@ -1,26 +1,50 @@
+"""Pydantic models for Javelina-RT code generator inputs and outputs.
+
+Input-side models (TopicId, TopicSpec, ParameterEntry, ParameterSet, Ports)
+represent parsed YAML data. Output-side models (GeneratedHeader and subclasses)
+carry all data needed to render a Jinja2 template into a C++ header.
+"""
 from typing import Any, Dict, List
 
 from pydantic import BaseModel, computed_field, model_validator
 
 
 class TopicId(BaseModel):
+    """C++ identifier pair for a DDS topic: human-readable name and constexpr var name."""
+
     name: str
     c_var_name: str
 
 
 class TopicSpec(BaseModel):
+    """Full specification for one DDS topic: PubSubType name, topic ID, and queue depth."""
+
     type: str
     topic_id: TopicId
     queue_size: int
 
 
 class ParameterEntry(BaseModel):
+    """A single parameter: C++ tag name, type string, and default value string."""
+
     name: str
     type: str
     value: str
 
 
 def normalize_type(raw_type: str) -> str:
+    """Converts a YAML type declaration to a C++ template argument string.
+
+    Scalars (``"float"``) pass through unchanged. Arrays (``"float[3]"``) expand
+    to comma-separated repetitions (``"float,float,float"``) for use as variadic
+    template arguments.
+
+    Args:
+        raw_type: YAML type string, e.g. ``"float"`` or ``"float[3]"``.
+
+    Returns:
+        C++ template argument string.
+    """
     # array are modeled as type[size] we're splitting using [
     # then if we have an array we output a comma separated list
     # e.g. float[3] => float,float,float.
@@ -39,6 +63,12 @@ def normalize_type(raw_type: str) -> str:
 
 
 class ParameterSet(BaseModel):
+    """Collection of ParameterEntry items read from a parameters YAML file.
+
+    The YAML root key becomes the set name (PascalCase). Each parameter name
+    is suffixed with ``"Tag"`` to form the C++ tag type name.
+    """
+
     name: str
     params: List[ParameterEntry]
 
@@ -65,10 +95,24 @@ class ParameterSet(BaseModel):
 
 
 def normalize_name(raw_name: str) -> str:
+    """Converts a snake_case identifier to PascalCase.
+
+    Args:
+        raw_name: Snake-case name, e.g. ``"max_speed"``.
+
+    Returns:
+        PascalCase string, e.g. ``"MaxSpeed"``.
+    """
     return "".join(word.capitalize() for word in raw_name.split("_"))
 
 
 class Ports(BaseModel):
+    """Subscriptions and publications parsed from a ports YAML file.
+
+    The model validator flattens the list-of-dicts YAML structure into typed
+    TopicSpec entries and applies defaults (queue_size=1 for publishers).
+    """
+
     subscriptions: List[TopicSpec]
     publications: List[TopicSpec]
 
@@ -107,16 +151,30 @@ class Ports(BaseModel):
         }
 
 
-# The upstream bazel rule is configured to generate header usable just using file name (#include "name.hpp")
-# It's code gen, we don't care about pretty folder structure,
-# so we scrape the path away 🐽
 def remove_bazel_prefix_path(path: str) -> str:
+    """Strips the directory prefix from a Bazel-generated path, returning just the filename.
+
+    Generated headers are included by filename only (``#include "name.hpp"``), so
+    the path prefix is irrelevant. It's codegen — we don't care about folder structure 🐽
+
+    Args:
+        path: Full path string, e.g. ``"bazel-out/.../foo.hpp"``.
+
+    Returns:
+        Filename only, e.g. ``"foo.hpp"``.
+    """
     parts = path.rsplit("/", 1)
     clean_path = parts[-1]
     return clean_path
 
 
 class GeneratedHeader(BaseModel):
+    """Base model for all generated C++ header files.
+
+    Provides the output path, include list, namespace, and a computed header
+    guard derived from the output filename.
+    """
+
     output_file_path: str
     includes: List[str]
     namespace: str
@@ -139,6 +197,11 @@ class GeneratedHeader(BaseModel):
 
 
 class IdlTypeHeader(GeneratedHeader):
+    """Header model listing the FastDDS-generated type include files.
+
+    Includes one ``*PubSubTypes.hpp`` per unique type referenced in ports.
+    """
+
     @model_validator(mode="before")
     @classmethod
     def preprocess(cls, data: Dict[str, Any]) -> Dict[str, Any]:
@@ -153,13 +216,19 @@ class IdlTypeHeader(GeneratedHeader):
 
 
 class TopicIdHeader(GeneratedHeader):
+    """Header model defining constexpr topic name string constants."""
+
     topic_ids: List[TopicId]
 
 
 class SpecsHeader(GeneratedHeader):
+    """Header model defining TopicSpec instantiations and a topic list type alias."""
+
     topic_specs: List[TopicSpec]
     specs_list_name: str
 
 
 class ParametersHeader(GeneratedHeader):
+    """Header model for the parameters.hpp output, wrapping a full ParameterSet."""
+
     params: ParameterSet

--- a/core/generators/gen_utils.py
+++ b/core/generators/gen_utils.py
@@ -1,3 +1,4 @@
+"""Model builders and YAML/IDL parsing utilities for the Javelina-RT code generator."""
 from typing import Any, Dict, List
 
 import yaml
@@ -18,6 +19,12 @@ DEFAULT_NAMESPACE = "gen"
 
 
 def _assert_type_exists(type_name: str, available_types: List[str]) -> None:
+    """Raises RuntimeError if type_name is not in available_types.
+
+    Args:
+        type_name: IDL struct name to verify.
+        available_types: List of struct names parsed from the provided IDL files.
+    """
     if type_name not in available_types:
         raise RuntimeError(
             f"Type '{type_name}' not found in any IDL. "
@@ -27,6 +34,17 @@ def _assert_type_exists(type_name: str, available_types: List[str]) -> None:
 
 
 def get_available_idl_types(idl_file_paths: List[str]) -> List[str]:
+    """Parses IDL files and returns all declared struct names.
+
+    Returns an empty list (with a warning) if parsing fails. The caller decides
+    whether to proceed without type validation.
+
+    Args:
+        idl_file_paths: Paths to .idl files.
+
+    Returns:
+        List of struct names found across all IDL files.
+    """
     available_types: List[str] = []
     try:
         parser = IDLParser()
@@ -42,6 +60,17 @@ def get_available_idl_types(idl_file_paths: List[str]) -> List[str]:
 
 
 def parse_yaml(yaml_path: str) -> Dict[str, Any]:
+    """Loads and returns the contents of a YAML file as a dict.
+
+    Args:
+        yaml_path: Path to the YAML file.
+
+    Returns:
+        Parsed YAML as a dict.
+
+    Raises:
+        RuntimeError: If the file cannot be parsed.
+    """
     with open(yaml_path, "r") as file:
         try:
             return yaml.safe_load(file)
@@ -50,6 +79,18 @@ def parse_yaml(yaml_path: str) -> Dict[str, Any]:
 
 
 def dds_ports_from_yaml(yaml_path: str, available_types: List[str]) -> Ports:
+    """Parses a ports YAML file and returns a Ports model.
+
+    Validates that all declared types exist in the IDL files when available_types
+    is non-empty. Raises RuntimeError on unknown types.
+
+    Args:
+        yaml_path: Path to the ports YAML config.
+        available_types: Parsed IDL struct names for validation; skip if empty.
+
+    Returns:
+        Populated Ports model.
+    """
     yaml_dict = parse_yaml(yaml_path)
     if available_types:
         for entry in (*yaml_dict["subscriptions"], *yaml_dict["publications"]):
@@ -60,6 +101,15 @@ def dds_ports_from_yaml(yaml_path: str, available_types: List[str]) -> Ports:
 def dds_types_header_model(
     ports: Ports, dds_types_header_output_path: str
 ) -> IdlTypeHeader:
+    """Builds the IdlTypeHeader model for the dds_types.hpp output.
+
+    Args:
+        ports: Ports model providing subscription and publication type names.
+        dds_types_header_output_path: Output path for the generated header.
+
+    Returns:
+        IdlTypeHeader model ready for template rendering.
+    """
     raw_model: Dict[str, Any] = {
         "output_file_path": dds_types_header_output_path,
         **ports.model_dump(),
@@ -72,7 +122,16 @@ def dds_topic_ids_pub_sub_header_models(
     dds_topic_ids_header_output_path: str,
     namespace: str = DEFAULT_NAMESPACE,
 ) -> TopicIdHeader:
+    """Builds a TopicIdHeader model listing topic name constants.
 
+    Args:
+        topic_ids: List of TopicId entries (pub or sub side).
+        dds_topic_ids_header_output_path: Output path for the generated header.
+        namespace: C++ namespace for the generated constants.
+
+    Returns:
+        TopicIdHeader model ready for template rendering.
+    """
     return TopicIdHeader(
         output_file_path=dds_topic_ids_header_output_path,
         topic_ids=topic_ids,
@@ -88,6 +147,18 @@ def dds_topic_specs_pub_sub_header_models(
     includes: List[str],
     namespace: str = DEFAULT_NAMESPACE,
 ) -> SpecsHeader:
+    """Builds a SpecsHeader model listing TopicSpec instantiations.
+
+    Args:
+        topic_specs: List of TopicSpec entries (pub or sub side).
+        dds_topic_specs_header_output_path: Output path for the generated header.
+        specs_list_name: C++ type alias name for the spec tuple (e.g. ``"Subscriptions"``).
+        includes: Headers to include in the generated file.
+        namespace: C++ namespace for the generated specs.
+
+    Returns:
+        SpecsHeader model ready for template rendering.
+    """
     model_raw: Dict[str, Any] = {
         "output_file_path": dds_topic_specs_header_output_path,
         "topic_specs": topic_specs,
@@ -100,12 +171,30 @@ def dds_topic_specs_pub_sub_header_models(
 
 
 def parameterset_model_from_yaml(yaml_path: str) -> ParameterSet:
+    """Parses a parameters YAML file and returns a ParameterSet model.
+
+    Args:
+        yaml_path: Path to the parameters YAML config.
+
+    Returns:
+        Populated ParameterSet model.
+    """
     return ParameterSet(**parse_yaml(yaml_path))
 
 
 def parameters_header_model(
     parameter_model: ParameterSet, header_output_path: str, namespace: str = DEFAULT_NAMESPACE
 ) -> ParametersHeader:
+    """Builds a ParametersHeader model for the parameters.hpp output.
+
+    Args:
+        parameter_model: ParameterSet model from YAML parsing.
+        header_output_path: Output path for the generated header.
+        namespace: C++ namespace for generated code.
+
+    Returns:
+        ParametersHeader model ready for template rendering.
+    """
     model_raw: Dict[str, Any] = {
         "output_file_path": header_output_path,
         "params": parameter_model,

--- a/core/generators/generators.py
+++ b/core/generators/generators.py
@@ -1,3 +1,9 @@
+"""Javelina-RT C++ code generator entry point.
+
+Dispatches to DDS ports or parameters generation based on the ``--modality``
+CLI argument. Reads a YAML configuration, optionally parses IDL files for type
+validation, and writes C++ headers via Jinja2 templates.
+"""
 import argparse
 import json
 import sys
@@ -24,11 +30,15 @@ from core.generators.gen_utils import (
 
 
 class Modality(Enum):
+    """Generation modality: DDS ports (pub/sub specs) or task parameters."""
+
     PORTS = "ports"
     PARAMETERS = "parameters"
 
 
 class _GeneratorArgs(NamedTuple):
+    """Parsed and validated CLI arguments returned by parse_arguments()."""
+
     modality: Modality
     yaml_cfg: str
     idls: List[str]
@@ -37,6 +47,13 @@ class _GeneratorArgs(NamedTuple):
 
 
 def parse_arguments() -> _GeneratorArgs:
+    """Parses CLI arguments and returns a validated _GeneratorArgs.
+
+    Exits with an error if the YAML file does not exist.
+
+    Returns:
+        _GeneratorArgs with modality, yaml path, IDL list, output paths, and namespace.
+    """
     parser = argparse.ArgumentParser(description="Javelina-rt C++ Code Generator")
 
     parser.add_argument(
@@ -88,7 +105,12 @@ def generate_header_file(
     template_path: str,
     model_instance: GeneratedHeader,
 ) -> None:
+    """Renders a Jinja2 template with model data and writes the result to disk.
 
+    Args:
+        template_path: Path to the .jinja template file.
+        model_instance: Pydantic model whose fields are passed to the template.
+    """
     template_content = Path(template_path).read_text()
 
     template = Template(template_content, trim_blocks=True, lstrip_blocks=True)
@@ -111,6 +133,16 @@ TEMPLATES: Dict[str, str] = {
 def generate_ports(
     yaml_cfg: str, idls: List[str], outputs: Dict[str, Any], namespace: str
 ) -> None:
+    """Generates the five DDS port headers from a YAML configuration.
+
+    Produces: dds_types, pub_ids, sub_ids, pub_specs, sub_specs headers.
+
+    Args:
+        yaml_cfg: Path to the ports YAML file.
+        idls: List of IDL file paths for type validation.
+        outputs: Dict mapping output keys to file paths (from Bazel rule).
+        namespace: C++ namespace for generated code.
+    """
     available_types = get_available_idl_types(idls)
     ports_model = dds_ports_from_yaml(yaml_cfg, available_types)
 
@@ -166,6 +198,13 @@ def generate_ports(
 
 
 def generate_parameters(yaml_cfg: str, outputs: Dict[str, Any], namespace: str) -> None:
+    """Generates a single parameters header from a YAML configuration.
+
+    Args:
+        yaml_cfg: Path to the parameters YAML file.
+        outputs: Dict with a ``"parameters"`` key pointing to the output path.
+        namespace: C++ namespace for generated code.
+    """
     parameters_model = parameterset_model_from_yaml(yaml_cfg)
     header_model = parameters_header_model(parameters_model, outputs["parameters"], namespace=namespace)
     generate_header_file(TEMPLATES["parameters"], header_model)
@@ -175,6 +214,7 @@ def generate_parameters(yaml_cfg: str, outputs: Dict[str, Any], namespace: str) 
 
 
 def main() -> None:
+    """CLI entry point. Parses arguments and dispatches to the appropriate generator."""
     args = parse_arguments()
     print("=================================================================")
     print(f"🐽 🐽 🐽 🐽 🐽 Running Javelina Generators [Modality={args.modality}]")

--- a/core/generators/parameters_gen.bzl
+++ b/core/generators/parameters_gen.bzl
@@ -1,3 +1,9 @@
+"""Bazel rule for generating a C++ parameters header from a YAML parameter set definition.
+
+Produces a single header per target. Prefer the cc_parameters macro in defs.bzl,
+which wires parameters_provider as a default dependency.
+"""
+
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//core/generators:cc_utils.bzl", "pack_cc_library")
 

--- a/core/lifecycle/data_endpoint.hpp
+++ b/core/lifecycle/data_endpoint.hpp
@@ -8,7 +8,21 @@
 #include "core/support/utils/size_constrained_queue.hpp"
 // this should be moved in communication
 namespace core::lifecycle {
+
+/// @brief Direction tag for @c DataEndpoint. @c In = subscriber, @c Out = publisher.
 enum class DataDirection { In, Out };
+
+/// @brief Generic DDS endpoint: subscriber (@c In) or publisher (@c Out) for one topic.
+///
+/// Uses @c if constexpr to instantiate only the relevant DDS primitive — the other
+/// member collapses to @c int. Owns the sample queue.
+///
+/// @c Sync() drives data transfer each step:
+/// - @c In: drains samples from the DDS listener queue into the local buffer.
+/// - @c Out: publishes the most recent queued sample if one is pending.
+///
+/// @tparam Spec A @c TopicSpec specialization defining type, name, and queue size.
+/// @tparam D    @c DataDirection::In (subscriber) or @c DataDirection::Out (publisher).
 template <typename Spec, DataDirection D>
 class DataEndpoint {
   static_assert(communication::is_topic_spec_v<Spec>,
@@ -30,6 +44,9 @@ class DataEndpoint {
       pub_.Start(Spec::kName);
     }
   }
+  /// @brief Synchronizes the endpoint with DDS.
+  ///        In: drains the listener queue into the local sample buffer.
+  ///        Out: publishes the latest queued sample (if any).
   void Sync() noexcept {
     if constexpr (D == DataDirection::In) {
       sub_.DrainQueue(queue_);
@@ -48,6 +65,8 @@ class DataEndpoint {
     return queue_[index];
   }
 
+  /// @brief Enqueues @p data for publishing on the next @c Sync().
+  ///        Only valid for @c DataDirection::Out endpoints.
   void Push(T&& data) {
     static_assert(D == DataDirection::Out, "Cannot push to an Input Source");
     queue_.Push(std::move(data));

--- a/core/lifecycle/dds_application.hpp
+++ b/core/lifecycle/dds_application.hpp
@@ -17,6 +17,16 @@ inline std::atomic<bool> shutdown_requested{false};
 inline void signal_handler(int) { shutdown_requested.store(true); }
 }  // namespace detail
 
+/// @brief Top-level application class for a DDS-based Javelina process.
+///
+/// Constructs the @c DDSContext, registers SIGINT/SIGTERM handlers, and builds
+/// the @c TasksManager from @p ApplicationConfig. Call @c Run() to block the
+/// main thread until a shutdown signal is received.
+///
+/// @p ApplicationConfig must be a @c LookupTable mapping task types (@c TaskInterface
+/// subclasses) to @c TaskSpec values. The engine starts automatically at construction.
+///
+/// @tparam ApplicationConfig A @c LookupTable of @c {TaskType -> TaskSpec} entries.
 template <typename ApplicationConfig>
 class DDSAPPlication final {
   static_assert(core::utils::is_lookup_table_v<ApplicationConfig>,
@@ -24,6 +34,8 @@ class DDSAPPlication final {
                 "core/support/utils/lookup_table.hpp");
 
  public:
+  /// @brief Constructs the application: sets up DDS, installs signal handlers, builds tasks.
+  /// @param domain_participant_name Name assigned to the FastDDS DomainParticipant.
   DDSAPPlication(const std::string domain_participant_name) {
     std::signal(SIGINT, detail::signal_handler);
     std::signal(SIGTERM, detail::signal_handler);

--- a/core/lifecycle/dds_task.hpp
+++ b/core/lifecycle/dds_task.hpp
@@ -7,6 +7,19 @@
 #include "core/lifecycle/task_interface.hpp"
 namespace core::lifecycle {
 
+/// @brief Base class for tasks that communicate over DDS.
+///
+/// Manages typed input and output @c DataEndpoint collections. On each
+/// @c ExecuteStep() call the engine:
+///   1. Drains all subscriber queues into the input buffers (@c FillInputs).
+///   2. Calls @c Execute() — the user-provided algorithm.
+///   3. Publishes all pending output buffers (@c FlushOutputs).
+///
+/// Access inputs via @c GetInputSource<TopicName>() and outputs via
+/// @c GetOutputSink<TopicName>() inside @c Execute().
+///
+/// @tparam SubscriptionSpecs @c TopicList of @c TopicSpec types for subscribed topics.
+/// @tparam PublicationSpecs  @c TopicList of @c TopicSpec types for published topics.
 template <typename SubscriptionSpecs, typename PublicationSpecs>
 class DDSTask : public TaskInterface {
   using Subs = SubscriptionSpecs;
@@ -23,14 +36,21 @@ class DDSTask : public TaskInterface {
   };
 
  protected:
+  /// @brief User algorithm. Called between @c FillInputs and @c FlushOutputs.
   virtual void Execute() = 0;
+
+  /// @brief Optional init hook. Called once before the first @c ExecuteStep(). No-op by default.
   virtual void Init() {}
 
+  /// @brief Returns a read-only view of the input endpoint for @p TopicName.
+  /// @tparam TopicName Compile-time string matching a subscribed @c TopicSpec::kName.
   template <const char* TopicName>
   inline auto GetInputSource() noexcept {
     return InputSource{get<TopicName>(inputs_)};
   }
 
+  /// @brief Returns a write-only view of the output endpoint for @p TopicName.
+  /// @tparam TopicName Compile-time string matching a published @c TopicSpec::kName.
   template <const char* TopicName>
   inline auto GetOutputSink() noexcept {
     return OutputSink{get<TopicName>(outputs_)};

--- a/core/lifecycle/execution_engine.hpp
+++ b/core/lifecycle/execution_engine.hpp
@@ -14,6 +14,8 @@ namespace core::lifecycle {
 
 using namespace std::chrono_literals;
 
+/// @brief A single scheduled work item: a deadline and a callback.
+///        Ordered by time (earliest first) in the priority queue.
 struct Job {
   std::chrono::steady_clock::time_point time;
   std::function<void()> callback;
@@ -22,6 +24,14 @@ struct Job {
   bool operator>(const Job& other) const { return time > other.time; }
 };
 
+/// @brief Single-threaded periodic task scheduler backed by a min-heap priority queue.
+///
+/// Each registered function wraps into a self-rescheduling callback: after execution
+/// it re-enqueues itself at @c now + period. The worker thread sleeps until the next
+/// deadline using @c condition_variable::wait_until.
+///
+/// Exceptions from callbacks are caught and logged; the failed task is not rescheduled.
+/// Non-copyable. Destruction automatically calls @c Stop().
 class ExecutionEngine final {
  public:
   ExecutionEngine() = default;
@@ -31,11 +41,22 @@ class ExecutionEngine final {
   ExecutionEngine(const ExecutionEngine&) = delete;
   ExecutionEngine& operator=(const ExecutionEngine&) = delete;
 
+  /// @brief Spawns the worker thread. No-op if already running.
   void Start();
+
+  /// @brief Clears the queue, signals the worker to exit, and joins it. Idempotent.
   void Stop();
 
+  /// @brief Registers a periodic task.
+  ///
+  /// First invocation fires at @c now + @p period. Re-schedules itself on every
+  /// execution. Call after @c Start().
+  ///
+  /// @param period Execution interval.
+  /// @param func   Callable invoked at each period.
   void Schedule(std::chrono::milliseconds period, std::function<void()> func);
 
+  /// @return True if the worker thread is currently running.
   [[nodiscard]] bool IsRunning() const { return running_.load(); }
   [[nodiscard]] int TaskQueueSize() const { return queue_.size(); }
 

--- a/core/lifecycle/input_source.hpp
+++ b/core/lifecycle/input_source.hpp
@@ -7,9 +7,12 @@
 
 namespace core::lifecycle {
 
-/**
- * @brief Read-Only View for Input DataEndpoints.
- */
+/// @brief Read-only view over an input @c DataEndpoint.
+///
+/// Returned by @c DDSTask::GetInputSource(). Provides indexed sample access
+/// and size queries; does not own the endpoint.
+///
+/// @tparam Spec @c TopicSpec specialization. Determines the data type and queue size.
 template <typename Spec>
 struct InputSource {
   static_assert(communication::is_topic_spec_v<Spec>,
@@ -18,6 +21,7 @@ struct InputSource {
   using T = typename Spec::type::type;
   const DataEndpoint<Spec, DataDirection::In>& endpoint;
 
+  /// @brief Accesses sample at index @p i (0 = newest, Size()-1 = oldest).
   [[nodiscard]] inline const utils::Sample<T>& operator[](
       size_t i) const noexcept {
     return endpoint[i];

--- a/core/lifecycle/output_sink.hpp
+++ b/core/lifecycle/output_sink.hpp
@@ -6,9 +6,13 @@
 
 namespace core::lifecycle {
 
-/**
- * @brief Write-Only View for Output DataPoints.
- */
+/// @brief Write-only view over an output @c DataEndpoint.
+///
+/// Returned by @c DDSTask::GetOutputSink(). Accepts one sample per step via
+/// @c Push(); the endpoint publishes it on the next @c Sync(). Does not own
+/// the endpoint.
+///
+/// @tparam Spec @c TopicSpec specialization. Determines the data type.
 template <typename Spec>
 struct OutputSink {
   static_assert(communication::is_topic_spec_v<Spec>,
@@ -17,6 +21,7 @@ struct OutputSink {
   using T = typename Spec::type;
   DataEndpoint<Spec, DataDirection::Out>& endpoint;
 
+  /// @brief Enqueues @p data for publishing on the next sync cycle.
   template <typename U>
   inline void Push(U&& data) {
     endpoint.Push(std::forward<U>(data));

--- a/core/lifecycle/parameters_provider.hpp
+++ b/core/lifecycle/parameters_provider.hpp
@@ -24,20 +24,33 @@ constexpr auto collapse_tuple(T&& t) {
   }
 }
 }  // namespace detail
-// Check unit test for example usage 🐽
-// core/lifecycle/test/parameters_provider_tests.cpp
+/// @brief Provides typed read/write access to a @c LookupTable of parameters.
+///
+/// @p Params is a @c LookupTable type. @p ParamsDefaults is a tuple of default
+/// value tuples, one per entry. Single-value entries are returned as the scalar
+/// directly; multi-value entries collapse into a @c std::array.
+///
+/// @see core/lifecycle/test/parameters_provider_tests.cpp for usage examples.
+///
+/// @tparam Params         @c LookupTable type defining the parameter schema.
+/// @tparam ParamsDefaults Tuple of default value tuples (order matches @p Params).
+// proudly AI-generated, human-reviewed
 template <typename Params, typename ParamsDefaults>
 class ParametersProvider {
  public:
+  /// @brief Returns the current value for @p ParameterTag.
+  ///        Single-value entries return the scalar; multi-value entries return a @c std::array.
+  /// @tparam ParameterTag Tag type identifying the parameter in @p Params.
   template <typename ParameterTag>
   constexpr auto GetParameterValue() const {
     return detail::collapse_tuple(parameters_.GetValue(ParameterTag{}));
   }
 
  protected:
-  // we don't want everyone to publically access set
-  // setting it protected enable building parameter server which updates
-  // parameter on rpc
+  // Protected to allow derived classes (e.g. a parameter server) to update values.
+  /// @brief Updates the value for @p ParameterTag.
+  /// @tparam ParameterTag Tag type identifying the parameter in @p Params.
+  /// @param  args         New values, forwarded into the parameter tuple.
   template <typename ParameterTag, typename... Args>
   void SetParameterValue(Args&&... args) {
     parameters_.GetValue(ParameterTag{}).values =

--- a/core/lifecycle/task_interface.hpp
+++ b/core/lifecycle/task_interface.hpp
@@ -6,13 +6,24 @@
 
 namespace core::lifecycle {
 
+/// @brief Abstract base for all Javelina tasks.
+///
+/// Derive from @c DDSTask (for DDS-connected tasks) or directly from this for
+/// custom scheduling. @c TasksManager calls @c ExecuteStep() at the configured
+/// period on a dedicated worker thread.
+///
+/// @see DDSTask
+/// @see TasksManager
 class TaskInterface {
  public:
   explicit TaskInterface(std::string name) : name_(std::move(name)) {}
   virtual ~TaskInterface() = default;
 
+  /// @brief Called by the execution engine at the configured period.
+  ///        Implementations must be non-blocking.
   virtual void ExecuteStep() = 0;
 
+  /// @return The task's name, as provided at construction.
   const std::string& Name() { return name_; }
 
  protected:

--- a/core/lifecycle/tasks_manager.hpp
+++ b/core/lifecycle/tasks_manager.hpp
@@ -8,6 +8,8 @@
 
 namespace core::lifecycle {
 
+/// @brief Specifies the execution period for a task.
+/// @tparam Ms Period in milliseconds. Must be > 0.
 template <std::chrono::milliseconds::rep Ms>
 struct TaskSpec {
   static constexpr std::chrono::milliseconds::rep kFrequency = Ms;
@@ -29,6 +31,11 @@ template <typename T>
 constexpr bool is_task_spec_v = is_task_spec<T>::value;
 }  // namespace
 
+/// @brief Owns and schedules a collection of @c TaskInterface instances.
+///
+/// Tasks are registered via @c AddTask() before the engine starts.
+/// The underlying @c ExecutionEngine handles periodic scheduling on a dedicated
+/// worker thread. Non-copyable.
 class TasksManager final {
  public:
   TasksManager() = default;
@@ -49,9 +56,10 @@ class TasksManager final {
     return *this;
   }
 
-  /**
-   * @brief Add new tasks with a given frequency in ms
-   */
+  /// @brief Registers and schedules a new task at the given period.
+  /// @tparam T  Task type. Must derive from @c TaskInterface.
+  /// @tparam Ms Execution period in milliseconds. Must be > 0.
+  /// @param name Task name, used for logging and identification.
   template <class T, std::chrono::milliseconds::rep Ms,
             std::enable_if_t<std::is_base_of_v<TaskInterface, T>, int> = 0>
   void AddTask(const std::string& name) {
@@ -64,7 +72,10 @@ class TasksManager final {
                       [task]() { task->ExecuteStep(); });
   }
 
+  /// @brief Starts the execution engine. Safe to call only once.
   void Start() { engine_->Start(); }
+
+  /// @brief Stops the execution engine and joins the worker thread. Idempotent.
   void Stop() { engine_->Stop(); }
 
  private:

--- a/core/lifecycle/type_traits.hpp
+++ b/core/lifecycle/type_traits.hpp
@@ -7,6 +7,10 @@
 
 namespace core::lifecycle {
 
+/// @brief FNV-1a 64-bit hash of a null-terminated string.
+///        Evaluated at compile time when passed a string literal.
+/// @param str Null-terminated string to hash.
+/// @return 64-bit FNV-1a hash value.
 constexpr uint64_t Hash(const char* str) {
   uint64_t h = 0xcbf29ce484222325;
   while (*str) {
@@ -15,8 +19,8 @@ constexpr uint64_t Hash(const char* str) {
   return h;
 }
 
-// Helper for finding the index of Input/Output by hash in a tuple
-// Input/Outputs core/lifecycle/endpoint.hpp
+/// @brief Implementation detail: linear scan over a tuple's element types,
+///        returning the index whose @c kHash equals @p Hash.
 template <uint64_t Hash, typename Tuple, typename Seq>
 struct find_hash_impl;
 
@@ -33,6 +37,10 @@ struct find_hash_impl<Hash, Tuple, std::index_sequence<Is...>> {
   static constexpr size_t value = get_index();
 };
 
+/// @brief Finds the index of the @c DataEndpoint in @p Tuple whose @c kHash equals @p TargetHash.
+///        Produces a compile error if not found.
+/// @tparam TargetHash Hash value to search for. Use @c Hash(TopicName) to compute.
+/// @tparam Tuple      @c std::tuple of @c DataEndpoint specializations.
 template <uint64_t TargetHash, typename Tuple>
 struct find_by_hash {
   static constexpr size_t value =
@@ -43,6 +51,10 @@ struct find_by_hash {
                 "Topic Name not found in the provided Spec List!");
 };
 
+/// @brief Tag-dispatched accessor: returns the @c DataEndpoint in @p storage
+///        whose @c TopicSpec::kName matches @p TopicName.
+///        Fails to compile if the name is not found.
+/// @tparam TopicName Compile-time string literal matching a @c TopicSpec::kName.
 template <const char* TopicName, typename Tuple>
 auto& get(Tuple& storage) {
   using T = std::decay_t<Tuple>;
@@ -52,6 +64,8 @@ auto& get(Tuple& storage) {
   return std::get<I>(storage);
 }
 
+/// @brief Typed list of @c TopicSpec entries.
+///        Passed as @c SubscriptionSpecs / @c PublicationSpecs to @c DDSTask.
 template <typename... Topics>
 using TopicList = std::tuple<Topics...>;
 

--- a/core/support/utils/lookup_table.hpp
+++ b/core/support/utils/lookup_table.hpp
@@ -20,6 +20,10 @@ struct single_type_extractor<std::tuple<Ts...>> {
   using type = std::tuple<Ts...>;
 };
 
+/// @brief One entry in a @c LookupTable: a tag type paired with one or more values.
+///
+/// @tparam KeyType    Tag type used for compile-time lookup. Typically an empty struct.
+/// @tparam ValueTypes Types of the values stored under this key.
 template <typename KeyType, typename... ValueTypes>
 struct TableItem {
   using Key = KeyType;
@@ -52,8 +56,13 @@ struct find_table_item<TargetKey, Last> {
                                   Last, void>;
 };
 
-// Below: Helpers to enable ordered independent (key-val) initialization of
-// LookupTable using tag dispatching use it for complex cases/initialization
+/// @brief Tag-dispatched initializer for one @c LookupTable entry.
+///
+/// Use with @c TableDefaults() / @c SetDefaults() to initialize tables with
+/// many entries, where positional initialization becomes error-prone.
+///
+/// @tparam Tag        Key type matching the corresponding @c TableItem::Key.
+/// @tparam ValueTypes Types of the values to store.
 template <typename Tag, typename... ValueTypes>
 struct Init {
   using Key = Tag;
@@ -72,11 +81,28 @@ constexpr const auto& find_val(const First& first, const Rest&... rest) {
   }
 }
 
+/// @brief Constructs the defaults tuple for a @c LookupTable using @c Init helpers.
+///        Order-independent: each @c Init is matched to its entry by tag.
 template <typename Table, typename... Inits>
 constexpr auto TableDefaults(const Inits&... inits) {
   return Table::SetDefaults(inits...);
 }
 
+/// @brief Compile-time heterogeneous key-value map backed by multiple inheritance.
+///
+/// Inherits from every @c TableItem, enabling tag-dispatched value lookup with
+/// no runtime overhead. Keys must be unique — a @c static_assert enforces this.
+///
+/// Example:
+/// @code
+/// struct SpeedTag {};
+/// struct TimeoutTag {};
+/// using MyTable = LookupTable<TableItem<SpeedTag, float>, TableItem<TimeoutTag, int>>;
+/// constexpr MyTable table({std::make_tuple(10.0f), std::make_tuple(500)});
+/// float v = table.GetValue<SpeedTag>();  // 10.0f
+/// @endcode
+///
+/// @tparam TableElements Pack of @c TableItem specializations. Keys must be unique.
 template <typename... TableElements>
 struct LookupTable : public TableElements... {
   // --- Your original consistency checks ---
@@ -109,6 +135,9 @@ struct LookupTable : public TableElements... {
   using get_values_t =
       typename find_table_item<Key, TableElements...>::type::Values;
 
+  /// @brief Returns the values for @p TargetKey as a const reference.
+  ///        Fails to compile if @p TargetKey is not present in the table.
+  /// @tparam TargetKey Tag type to look up.
   template <typename TargetKey>
   constexpr const auto& GetValue() const {
     using ItemBase =
@@ -130,6 +159,9 @@ struct LookupTable : public TableElements... {
     return GetValue<Tag>();
   }
 
+  /// @brief Calls @p func once per table entry, passing a default-constructed element.
+  ///        Useful for iterating over entry types without a table instance.
+  /// @tparam Func Callable accepting any @c TableItem by value.
   template <typename Func>
   static constexpr void for_each(Func&& func) {
     (func(TableElements{}), ...);
@@ -142,6 +174,7 @@ struct LookupTable : public TableElements... {
       : TableElements{{std::get<Is>(defaults)}}... {}
 };
 
+/// @brief True iff @p T is a @c LookupTable specialization.
 template <typename T>
 constexpr bool is_lookup_table_v = false;
 

--- a/core/support/utils/size_constrained_queue.hpp
+++ b/core/support/utils/size_constrained_queue.hpp
@@ -11,12 +11,22 @@ namespace core::utils {
 using Clock = std::chrono::steady_clock;
 using Timestamp = std::chrono::time_point<Clock>;
 
+/// @brief A timestamped data sample produced by @c SizeConstrainedQueue::Push().
+/// @tparam T Data type of the stored value.
 template <typename T>
 struct Sample {
   Timestamp time_received;
   T data;
 };
 
+/// @brief Fixed-capacity circular buffer storing the @p N most recent samples.
+///
+/// Newer samples overwrite older ones once capacity is reached. Index 0 is
+/// always the most recently pushed sample (reverse-chronological order).
+/// All mutating operations are thread-safe via @c mtx_.
+///
+/// @tparam T Element type.
+/// @tparam N Maximum number of samples. Must be > 0.
 template <typename T, std::size_t N>
 class SizeConstrainedQueue {
   static_assert(N > 0, "SizeConstrainedQueue size must be greater than 0");
@@ -40,6 +50,8 @@ class SizeConstrainedQueue {
     return buffer_[(h + N - 1 - index) % N];
   }
 
+  /// @brief Pushes @p message into the queue, overwriting the oldest sample if full.
+  ///        Timestamps the sample with the current steady clock.
   template <typename U>
   void Push(U&& message) {
     static_assert(std::is_convertible_v<std::decay_t<U>, T>,
@@ -60,6 +72,8 @@ class SizeConstrainedQueue {
     }
   }
 
+  /// @brief Removes and returns the most recent sample.
+  /// @return The sample, or @c std::nullopt if empty.
   std::optional<Sample<T>> GetSample() {
     std::scoped_lock lock(mtx_);
 
@@ -83,6 +97,8 @@ class SizeConstrainedQueue {
     return count_.load(std::memory_order_relaxed);
   }
 
+  /// @brief Atomically moves all samples into @p other, replacing its contents.
+  ///        @c this is cleared. Both queues are locked simultaneously.
   inline void TransferTo(SizeConstrainedQueue<T, N>& other) noexcept {
     std::scoped_lock lock(mtx_, other.mtx_);
 
@@ -101,6 +117,7 @@ class SizeConstrainedQueue {
     this->head_.store(0, std::memory_order_relaxed);
   }
 
+  /// @return Maximum number of samples this queue can hold.
   constexpr std::size_t capacity() const noexcept { return N; }
 
  private:


### PR DESCRIPTION
## Summary

- **C++**: Doxygen `///` comments on all public APIs in `communication/`, `lifecycle/`, and `support/` — class descriptions, `@tparam`, `@param`, `@return`, `@throws` where relevant. Hover info now works in clangd for every public class and method.
- **Python**: Google-style docstrings on all functions and Pydantic models in `generators/` — module, class, and function level.
- **Starlark**: Module docstrings on all `.bzl` files that had placeholder text; `cc_parameters` macro was missing its docstring entirely.

23 files, +502 lines of documentation, no logic changes.

— Hamlet 🐗