### PR TITLE
Fixes for DDSContextProvider templatization

### DIFF
--- a/core/communication/BUILD
+++ b/core/communication/BUILD
@@ -13,7 +13,7 @@ cc_library(
     ],
     deps = [
         "//core/support/utils",
-        "@boost.core//:core",
+        "@boost.core//:boost.core",
         "@fastdds",
     ],
 )

--- a/core/pybinds/py_dds_bridge.hpp
+++ b/core/pybinds/py_dds_bridge.hpp
@@ -14,14 +14,20 @@ class PyDDSBridge {
   using Pubs = PublicationSpecs;
 
  public:
-  explicit PyDDSBridge(const std::string& participant_name) {
-    core::communication::DDSContextProvider::SetName(participant_name);
+  explicit PyDDSBridge(
+      const std::string& /*participant_name*/)  // @TODO: new DDSContextProvider
+                                                // API derives the name from the
+                                                // tag type, not a runtime
+                                                // string. To revisit this once
+                                                // the rework is done.
+  {
+    core::communication::DDSContextProvider<>::Get();  // trigger singleton init
   }
 
   // Returns the name the live DomainParticipant was created with.
   [[nodiscard]] std::string ParticipantName() const {
     auto participant =
-        core::communication::DDSContextProvider::Get().GetDomainParticipant();
+        core::communication::DDSContextProvider<>::Get().GetDomainParticipant();
     eprosima::fastdds::dds::DomainParticipantQos qos;
     participant->get_qos(qos);
     return qos.name().c_str();


### PR DESCRIPTION
**Changelog:**\
- `core/communication/BUILD`: corrected Boost dep from @boost.core//:core to @boost.core//:boost.core (target name in generated BUILD)
- `core/pybinds/py_dds_bridge.hpp`: removed stale `SetName` call and unqualified `DDSContextProvider` usage; both updated to `DDSContextProvider<>` (defaults to `DefaultContext`). `participant_name` parameter kept for API compat, marked with a TODO pending the rework.


----
**Cheatsheet**
- Running status checks -> Comment PR with :pig_nose:


